### PR TITLE
nord.lua: fix colors, make usable

### DIFF
--- a/colors/nord.lua
+++ b/colors/nord.lua
@@ -1,24 +1,29 @@
 local style = require "core.style"
 local common = require "core.common"
+local config = require "core.config"
 
 style.background = { common.color "#2E3440" }
-style.background2 = { common.color "#3B4252" }
+style.background2 = { common.color "#2E3440" }
 style.background3 = { common.color "#3B4252" }
 style.text = { common.color "#D8DEE9" }
 style.caret = { common.color "#D8DEE9" }
 style.accent = { common.color "#88C0D0" }
-style.dim = { common.color "#5E81AC" }
+style.dim = { common.color "#d8dee966" }
 style.divider = { common.color "#3B4252" }
-style.selection = { common.color "#434C5E" }
+style.selection = { common.color "#434C5ECC" }
 style.line_number = { common.color "#4C566A" }
 style.line_number2 = { common.color "#D8DEE9" }
-style.line_highlight = { common.color "#434C5E" }
-style.scrollbar = { common.color "#4C566A" }
-style.scrollbar2 = { common.color "#D8DEE9" }
+style.line_highlight = { common.color "#3B4252" }
+style.scrollbar = { common.color "#434c5eaa" }
+style.scrollbar2 = { common.color "#434c5e" }
+style.good = { common.color "#72b886cc" }
+style.warn = { common.color "#d08770" }
+style.error = { common.color "#bf616a" }
+style.modified = { common.color "#ebcb8b" }
 
 style.syntax["normal"] = { common.color "#ECEFF4" }
 style.syntax["symbol"] = { common.color "#D8DEE9" }
-style.syntax["comment"] = { common.color "#4C566A" }
+style.syntax["comment"] = { common.color "#616E88" }
 style.syntax["keyword"] = { common.color "#81A1C1" }
 style.syntax["keyword2"] = { common.color "#81A1C1" }
 style.syntax["number"] = { common.color "#B48EAD" }
@@ -26,3 +31,9 @@ style.syntax["literal"] = { common.color "#81A1C1" }
 style.syntax["string"] = { common.color "#A3BE8C" }
 style.syntax["operator"] = { common.color "#81A1C1" }
 style.syntax["function"] = { common.color "#88C0D0" }
+
+config.highlight_current_line = "no_selection"
+
+style.guide = { common.color "#434c5eb3" }
+style.bracketmatch_color = { common.color "#8fbcbb" }
+


### PR DESCRIPTION
To be honest, the theme was absolutely not usable with faded incorrect colors, no visible selection and a sidebar that was too eye-catching. I took the colors from the official [vim](https://github.com/arcticicestudio/nord-vim/blob/develop/colors/nord.vim) and [vscode](https://github.com/arcticicestudio/nord-visual-studio-code/blob/develop/themes/nord-color-theme.json) themes.
This PR requires: https://github.com/lite-xl/lite-xl/pull/752 and https://github.com/lite-xl/lite-xl/pull/753
Supports: https://github.com/lite-xl/lite-xl/pull/749