### PR TITLE
add version config to ayu-mirage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,7 @@
          "id": "ayu-mirage",
          "remote": "https://github.com/juliardi/lite-xl-ayu-theme.git:33a514527d4870480554771c273e667eb6418873",
          "type": "color",
+         "version": "0.1",
          "tags": [
             "dark"
          ]


### PR DESCRIPTION
When running LPM to install a package, it outputs a warning "warning: ayu-mirage stub on https://github.com/lite-xl/lite-xl-colors.git:master has differing version from remote (1.0 vs 0.1); may lead to install being inconsistent". This PR should fix that.